### PR TITLE
Fix for arangodb 3.3 - rely on JSON.parse() instead of string parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,13 @@ const url  = require('url');
 
 
 const mapTextToType = {
-    'insert/update':'2300',
-    'delete':'2302'
+    'insert/update':2300,
+    'delete':2302
 };
-const mapTypeToText = {
-    '2300': 'insert/update',
-    '2302': 'delete'
-};
+const mapTypeToText = new Map([
+     [2300, 'insert/update'],
+     [2302, 'delete']
+]);
 
 
 
@@ -60,40 +60,28 @@ class ArangoChair extends EventEmitter {
 
             let type  = 0;
             let tid   = 0;
-            let entry = 0;
-
-            let typeStartIdx = 0;
-            let typeEndIdx   = 0;
-            let idx0 = 0;
-            let idx1 = 0;
-
-            const typeStartBuffer       = Buffer.from('type":');
-            const cnameStartBuffer      = Buffer.from('cname":"');
-            const keyStartBuffer        = Buffer.from('_key":"');
-            const commaDoubleTickBuffer = Buffer.from(',"');
+            let entry;
 
             const txns = new Map();
 
             const handleEntry = () => {
-                idx0 = entry.indexOf(cnameStartBuffer, idx0 + 2) + 8;
-                idx1 = entry.indexOf(commaDoubleTickBuffer, idx0) - 1;
 
-                const colName = entry.slice(idx0, idx1).toString();
+                const colName = entry.cname;
 
                 const colConf = this.collectionsMap.get(colName);
+
                 if (undefined === colConf) return;
 
                 const events = colConf.get('events');
 
-                if (0 !== events.size && !events.has(type)) return;
+                if (0 !== events.size && !events.has(type)) return;
 
-                idx0 = entry.indexOf(keyStartBuffer, idx1 + 9);
-                const key = entry.slice(idx0+7, entry.indexOf(commaDoubleTickBuffer, idx0+7)-1).toString();
+                const key = entry.data._key
                 const keys = colConf.get('keys');
 
                 if (0 !== keys.size && !events.has(key)) return;
 
-                this.emit(colName, entry.slice(idx1 + 9, -1), mapTypeToText[type]);
+                this.emit(colName, entry.data, mapTypeToText.get(type));
             };
 
             const ticktock = () => {
@@ -117,39 +105,35 @@ class ArangoChair extends EventEmitter {
                         idx = body.indexOf('\n', start);
                         if (-1 === idx) break;
 
-                        entry = body.slice(start, idx);
+                        entry = JSON.parse(body.slice(start, idx));
                         start = idx+1;
 
                         // transaction   {"tick":"514132959101","type":2200,"tid":"514132959099","database":"1"}
                         // insert/update {"tick":"514092205556","type":2300,"tid":"0","database":"1","cid":"513417247371","cname":"test","data":{"_id":"test/testkey","_key":"testkey","_rev":"514092205554",...}}
                         // delete        {"tick":"514092206277","type":2302,"tid":"0","database":"1","cid":"513417247371","cname":"test","data":{"_key":"abcdef","_rev":"514092206275"}}
 
-                        idx0 = entry.indexOf(typeStartBuffer) + 6;            // find type":
-                        idx1 = entry.indexOf(commaDoubleTickBuffer, idx0);    // find ,"
-                        type = entry.slice(idx0, idx1).toString();
+                        type = entry.type
 
-                        idx0 = entry.indexOf(commaDoubleTickBuffer, idx1+8) - 1; // find ,"
-                        tid  = entry.slice(idx1+8, idx0).toString();
+                        tid  = entry.tid
 
-                        if ('2200' === type) { // txn start
+                        if (2200 === type) { // txn start
                             txns.set(tid, new Set());
 
-                        } else if ('2201' === type) { // txn commit and replay docs
+                        } else if (2201 === type) { // txn commit and replay docs
                             for(const data of txns.get(tid)) {
-                                idx0 = 0;
                                 [type, entry] = data;
                                 handleEntry();
                             } // for
                             txns.delete(tid);
 
-                        } else if ('2002' === type) { // txn abort
+                        } else if (2002 === type) { // txn abort
                             txns.delete(tid);
 
                         } else {
-                            if ('2300' !== type && '2302' !== type) continue;
+                            if (2300 !== type && 2302 !== type) continue;
 
                             if ('0' !== tid) {
-                                txns.get(tid).add([type,entry.slice(idx0+14)]);
+                                txns.get(tid).add([type,entry]);
                                 continue;
                             } // if
 


### PR DESCRIPTION
Although arangochair works fine with arangodb 3.1, I had errors with 3.3. It seems the format changed a bit and the current string parser fails.

Here is a fix relying on JSON.parse() instead of parsing the string which seems more robust against format changes.