### PR TITLE
Emit separate events for inserts and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ no4.on('users', (doc, type) => {
     // do something awesome
 
     // doc:Buffer
-    // type:'insert/update'|'delete'
+    // type:'insert'|'update'|'delete'
 });
 
 no4.on('error', (err, httpStatus, headers, body) => {
@@ -40,7 +40,7 @@ no4.on('error', (err, httpStatus, headers, body) => {
 no4.subscribe('users');
 
 // explicit
-no4.subscribe({collection:'users', events:['insert/update', 'delete']});
+no4.subscribe({collection:'users', events:['insert', 'update', 'delete']});
 
 
 // subscribe the users collection with only the delete event

--- a/index.js
+++ b/index.js
@@ -2,34 +2,25 @@
 
 const EventEmitter = require('events');
 
-const https = require('request-easy').https; 
-const http  = require('request-easy').http;
-const url  = require('url');
-
-
-const mapTextToType = {
-    'insert/update':'2300',
-    'delete':'2302'
-};
-const mapTypeToText = {
-    '2300': 'insert/update',
-    '2302': 'delete'
-};
-
-
+const https = require('request-easy').https;
+const http = require('request-easy').http;
+const url = require('url');
 
 class ArangoChair extends EventEmitter {
+
     constructor(adbUrl) {
+
         super();
+
         adbUrl = url.parse(adbUrl);
-        this.req = new (adbUrl.protocol === 'https:'? https : http)({
-            hostname:adbUrl.hostname,
-            port:adbUrl.port
+        this.req = new (adbUrl.protocol === 'https:' ? https : http)({
+            hostname: adbUrl.hostname,
+            port: adbUrl.port
         });
 
         const db = '/' === adbUrl.pathname ? '/_system' : adbUrl.pathname;
 
-        this._loggerStatePath  = `/_db${db}/_api/replication/logger-state`;
+        this._loggerStatePath = `/_db${db}/_api/replication/logger-state`;
         this._loggerFollowPath = `/_db${db}/_api/replication/logger-follow`;
 
         this.collectionsMap = new Map();
@@ -46,60 +37,54 @@ class ArangoChair extends EventEmitter {
     }
 
     _startLoggerState() {
-        this.req.get({path:this._loggerStatePath}, (status, headers, body) => {
+
+        this.req.get({path: this._loggerStatePath}, (status, headers, body) => {
+
             if (200 !== status) {
+
                 this.emit('error', new Error('E_LOGGERSTATE'), status, headers, body);
                 this.stop();
+
                 return;
-            } // if
+            }
 
             body = JSON.parse(body);
+
             let lastLogTick = body.state.lastLogTick;
-            let start = 0;
-            let idx   = 0;
-
-            let type  = 0;
-            let tid   = 0;
-            let entry = 0;
-
-            let typeStartIdx = 0;
-            let typeEndIdx   = 0;
-            let idx0 = 0;
-            let idx1 = 0;
-
-            const typeStartBuffer       = Buffer.from('type":');
-            const cnameStartBuffer      = Buffer.from('cname":"');
-            const keyStartBuffer        = Buffer.from('_key":"');
-            const commaDoubleTickBuffer = Buffer.from(',"');
+            let type;
+            let tid;
+            let entry;
 
             const txns = new Map();
 
             const handleEntry = () => {
-                idx0 = entry.indexOf(cnameStartBuffer, idx0 + 2) + 8;
-                idx1 = entry.indexOf(commaDoubleTickBuffer, idx0) - 1;
 
-                const colName = entry.slice(idx0, idx1).toString();
+                const colName = entry.cname;
 
                 const colConf = this.collectionsMap.get(colName);
                 if (undefined === colConf) return;
 
                 const events = colConf.get('events');
+                const event = this.inferEventType(tid, type);
 
-                if (0 !== events.size && !events.has(type)) return;
+                if (0 !== events.size && !events.has(event)) return;
 
-                idx0 = entry.indexOf(keyStartBuffer, idx1 + 9);
-                const key = entry.slice(idx0+7, entry.indexOf(commaDoubleTickBuffer, idx0+7)-1).toString();
+                const key = entry.data._key;
                 const keys = colConf.get('keys');
 
                 if (0 !== keys.size && !events.has(key)) return;
 
-                this.emit(colName, entry.slice(idx1 + 9, -1), mapTypeToText[type]);
+                const doc = entry.data;
+
+                this.emit(colName, doc, typeText);
             };
 
             const ticktock = () => {
+
                 if (this._stopped) return;
 
-                this.req.get({path:`${this._loggerFollowPath}?from=${lastLogTick}`}, (status, headers, body) => {
+                this.req.get({path: `${this._loggerFollowPath}?from=${lastLogTick}`}, (status, headers, body) => {
+
                     if (204 < status || 0 === status) {
                         this.emit('error', new Error('E_LOGGERFOLLOW'), status, headers, body);
                         this.stop();
@@ -112,107 +97,113 @@ class ArangoChair extends EventEmitter {
 
                     lastLogTick = headers['x-arango-replication-lastincluded'];
 
-                    start = idx = 0;
-                    while(true) {
-                        idx = body.indexOf('\n', start);
-                        if (-1 === idx) break;
+                    const entries = body.toString().trim().split('\n');
 
-                        entry = body.slice(start, idx);
-                        start = idx+1;
+                    for (const i in entries) {
+
+                        entry = JSON.parse(entries[i]);
 
                         // transaction   {"tick":"514132959101","type":2200,"tid":"514132959099","database":"1"}
                         // insert/update {"tick":"514092205556","type":2300,"tid":"0","database":"1","cid":"513417247371","cname":"test","data":{"_id":"test/testkey","_key":"testkey","_rev":"514092205554",...}}
                         // delete        {"tick":"514092206277","type":2302,"tid":"0","database":"1","cid":"513417247371","cname":"test","data":{"_key":"abcdef","_rev":"514092206275"}}
 
-                        idx0 = entry.indexOf(typeStartBuffer) + 6;            // find type":
-                        idx1 = entry.indexOf(commaDoubleTickBuffer, idx0);    // find ,"
-                        type = entry.slice(idx0, idx1).toString();
+                        type = entry.type;
+                        tid = entry.tid;
 
-                        idx0 = entry.indexOf(commaDoubleTickBuffer, idx1+8) - 1; // find ,"
-                        tid  = entry.slice(idx1+8, idx0).toString();
-
-                        if ('2200' === type) { // txn start
+                        if (2200 === type) { // txn start
                             txns.set(tid, new Set());
-
-                        } else if ('2201' === type) { // txn commit and replay docs
-                            for(const data of txns.get(tid)) {
-                                idx0 = 0;
+                        } else if (2201 === type) { // txn commit and replay docs
+                            for (const data of txns.get(tid)) {
                                 [type, entry] = data;
                                 handleEntry();
                             } // for
                             txns.delete(tid);
-
-                        } else if ('2002' === type) { // txn abort
+                        } else if (2002 === type) { // txn abort
                             txns.delete(tid);
-
                         } else {
-                            if ('2300' !== type && '2302' !== type) continue;
+
+                            if (2300 !== type && 2302 !== type) continue;
 
                             if ('0' !== tid) {
-                                txns.get(tid).add([type,entry.slice(idx0+14)]);
+                                txns.get(tid).add([type, entry]);
                                 continue;
-                            } // if
+                            }
 
                             handleEntry();
-                        } // else
-                    } // while
+                        }
+                    }
                     ticktock();
                 });
-            }
+            };
             ticktock();
         });
     }
 
-    subscribe(confs) {
-        if ('string' === typeof confs) confs = {collection:confs};
-        if (!Array.isArray(confs))     confs = [confs];
+    inferEventType(tid, type) {
 
-        for(const conf of confs) {
+        if (type === 2300) {    // type 2300 means insert or update
+            return tid === '0' ? "insert" : "update";    // the tid tells us which of the above it is
+        }
+
+        if (type === 2302) {     // type 2302 means delete
+            return "delete";
+        }
+    }
+
+    subscribe(confs) {
+
+        if ('string' === typeof confs) confs = {collection: confs};
+        if (!Array.isArray(confs)) confs = [confs];
+
+        for (const conf of confs) {
+
             let colConfMap = undefined;
+
             if (this.collectionsMap.has(conf.collection)) {
                 colConfMap = this.collectionsMap.get(conf.collection);
             } else {
-                colConfMap = new Map([ ['events', new Set()],['keys', new Set()] ]);
+                colConfMap = new Map([['events', new Set()], ['keys', new Set()]]);
                 this.collectionsMap.set(conf.collection, colConfMap);
             }
 
             if (conf.events) {
-                for(const event of conf.events) {
-                    colConfMap.get('events').add(mapTextToType[event]);
-                } // for
-            } // if
+                for (const event of conf.events) {
+                    colConfMap.get('events').add(event);
+                }
+            }
+
             if (conf.keys) {
-                for(const key of conf.keys) {
+                for (const key of conf.keys) {
                     colConfMap.get('keys').add(key);
-                } // for
-            } // if
-        } // for
-    } // subscribe()
+                }
+            }
+        }
+    }
 
     unsubscribe(confs) {
-        if ('string' === typeof confs) confs = {collection:confs};
-        if (!Array.isArray(confs))     confs = [confs];
 
-        for(const conf of confs) {
+        if ('string' === typeof confs) confs = {collection: confs};
+        if (!Array.isArray(confs)) confs = [confs];
+
+        for (const conf of confs) {
             if (conf.events) {
                 const events = this.collectionsMap.get(conf.collection).get('events');
-                for(const event of conf.events) {
-                    events.delete(mapTextToType[event]);
-                } // for
-            } // if
+                for (const event of conf.events) {
+                    events.delete(event);
+                }
+            }
             if (conf.keys) {
                 const keys = this.collectionsMap.get(conf.collection).get('keys');
-                for(const key of conf.keys) {
+                for (const key of conf.keys) {
                     keys.delete(key);
-                } // for
-            }// if
+                }
+            }
 
             if (!conf.events && !conf.keys) {
                 this.collectionsMap.delete(conf.collection);
-            } // if
-        } // for
-    } // unsubscribe()
+            }
+        }
+    }
 }
-
 
 module.exports = ArangoChair;

--- a/index.js
+++ b/index.js
@@ -59,9 +59,9 @@ class ArangoChair extends EventEmitter {
 
             const handleEntry = () => {
 
-                const colName = entry.cname;
+                const collectionName = entry.cname;
 
-                const colConf = this.collectionsMap.get(colName);
+                const colConf = this.collectionsMap.get(collectionName);
                 if (undefined === colConf) return;
 
                 const events = colConf.get('events');
@@ -76,7 +76,7 @@ class ArangoChair extends EventEmitter {
 
                 const doc = entry.data;
 
-                this.emit(colName, doc, typeText);
+                this.emit(collectionName, doc, event);
             };
 
             const ticktock = () => {


### PR DESCRIPTION
I was able to figure out how to emit separate events for inserts and updates instead of just having one "insert/update" event. Also, the field parsing code was not working with Arango v3.4.5, so I used JSON#parse instead of reading fields based on their indexed positions in the JSON string.